### PR TITLE
Update APKBUILD to point to latest 1.0.18

### DIFF
--- a/main/lksctp-tools/APKBUILD
+++ b/main/lksctp-tools/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=lksctp-tools
-pkgver=1.0.17
+pkgver=1.0.18
 pkgrel=0
 pkgdesc="User-space access to Linux Kernel SCTP"
 url="http://lksctp.sourceforge.net"
@@ -11,7 +11,7 @@ depends=""
 makedepends="libtool automake autoconf linux-headers"
 install=""
 subpackages="$pkgname-dev $pkgname-doc"
-source="https://downloads.sourceforge.net/lksctp/lksctp-tools-$pkgver.tar.gz"
+source="https://github.com/sctp/lksctp-tools/archive/lksctp-tools-$pkgver.tar.gz"
 
 prepare() {
 	cd "$builddir"
@@ -40,4 +40,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="055719130b7dda4da9cf002dcd5f1fb3d8cf75300a99365976e087b2b6971b4ccd357f95b515a44e37874af161f7b7f9b42c60191aff938d18fada5a49aa44c4  lksctp-tools-1.0.17.tar.gz"
+sha512sums="a47dbdf5082ce056c3749237ab83889a134f30b3b4a4c66701fa8c6dc955cf06a1f406677320e6e3535d4e635a89344b67ee461991a10a95460ea191cf5b71f6  lksctp-tools-1.0.18.tar.gz"


### PR DESCRIPTION
sctp/lksctp-tools hosted on Github has latest release version.